### PR TITLE
Add wssPort to client configuration

### DIFF
--- a/getting-started/client-configuration/laravel-echo.md
+++ b/getting-started/client-configuration/laravel-echo.md
@@ -12,6 +12,7 @@ let laravelEcho = new Echo({
     key: process.env.MIX_PUSHER_APP_KEY,
     wsHost: process.env.MIX_PUSHER_HOST,
     wsPort: process.env.MIX_PUSHER_PORT,
+    wssPort: process.env.MIX_PUSHER_PORT,
     forceTLS: false,
     encrypted: true,
     disableStats: true,


### PR DESCRIPTION
The wsPort config is only used by pusher-js for ws connections, so we must specify wssPort for things to work out of the box with the wss protocol.