### PR TITLE
update docker run command to expose /usage endpoint on port 9601

### DIFF
--- a/getting-started/installation/docker.md
+++ b/getting-started/installation/docker.md
@@ -7,7 +7,7 @@ Starting with 0.27, you can now also deploy soketi on ARM-based devices using Do
 soketi is also available via pre-built Docker images. To get started, you may simply run one of our available images:
 
 ```bash
-docker run -p 6001:6001 quay.io/soketi/soketi:0.17-16-alpine
+docker run -p 6001:6001 -p 9601:9601 quay.io/soketi/soketi:0.17-16-alpine
 ```
 
 ### Alpine-based Images


### PR DESCRIPTION
Small update to the docker run command to expose /usage endpoint on port 9601.


![image](https://user-images.githubusercontent.com/49455868/154094865-d4c8b9b6-c693-455d-8361-a4b3fc31971a.png)

![image](https://user-images.githubusercontent.com/49455868/154095784-9b6ebe4f-fda2-46f8-829e-3c1fb3e8d5df.png)