### PR TITLE
Comma in the wrong place, maybe a typo

### DIFF
--- a/getting-started/environment-variables.md
+++ b/getting-started/environment-variables.md
@@ -36,7 +36,7 @@ Starting with soketi `0.24`, you can define a JSON-formatted file which can cont
     "appManager.array.apps.0.secret": "some-secret",
     "appManager.array.apps.0.webhooks": [{
         "url": "https://...",
-        "event_types": ["channel_occupied"],
+        "event_types": ["channel_occupied"]
     }],
     "debug": true,
     "port": 6002


### PR DESCRIPTION
There is a comma at the end of  "event_types": ["channel_occupied"] that ruined the json file example, so maybe it was a typo when removing something else.

It took me a few minutes to find this problem when I used this example, so in order to avoid other people run in the same problem as myself I'm sending this PR. 