### PR TITLE
fix(installation): fix env vars for laravel sail installation

### DIFF
--- a/getting-started/installation/laravel-sail-docker.md
+++ b/getting-started/installation/laravel-sail-docker.md
@@ -11,8 +11,8 @@ services:
     soketi:
         image: 'quay.io/soketi/soketi:latest-16-alpine'
         environment:
-            DEBUG: '1'
-            METRICS_SERVER_PORT: '9601'
+            SOKETI_DEBUG: '1'
+            SOKETI_METRICS_SERVER_PORT: '9601'
         ports:
             - '${SOKETI_PORT:-6001}:6001'
             - '${SOKETI_METRICS_SERVER_PORT:-9601}:9601'


### PR DESCRIPTION
**What type of PR is this?**
Fix: A bug fix

**What this PR does / why we need it:**
- update for env vars docs for laravel sail installation

**Special notes for your reviewer:**
Since `1.x` release soketi env vars are prefixed with `SOKETI_`. 

When I was testing out soketi with Sail I noticed that the documentation had a section for it (awesome work 🙏) and copy/pasted the code snippet but i wasn't getting logs from the docker container when events were being dispatched. 

I hope this PR is targetting the correct version for the documentation by changing the `1.x`documentation version and keeping the `0.x` docs intact.